### PR TITLE
Verifying support for non-supported explorers

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,7 +2,7 @@ require("@nomiclabs/hardhat-waffle");
 require("@nomiclabs/hardhat-ethers");
 require("@nomiclabs/hardhat-etherscan");
 const { CHAINS } = require("@pangolindex/sdk");
-require('dotenv').config();
+require("dotenv").config();
 
 // Create hardhat networks from @pangolindex/sdk
 let networksFromSdk = {};
@@ -28,6 +28,25 @@ task("accounts", "Prints the list of accounts", async () => {
   }
 });
 
+// To learn which networks are defined
+task(
+  "networks",
+  "Lists all networks defined in the hardhat.config.js file",
+  async () => {
+    // Load the hardhat.config.js file
+    const configFilePath = path.resolve(__dirname, "hardhat.config.js");
+    const config = require(configFilePath);
+
+    // Get the networks defined in the config file
+    const networks = config.networks;
+
+    // Print the name of each network
+    for (const networkName in networks) {
+      console.log(networkName);
+    }
+  }
+);
+
 /**
  * @type import('hardhat/config').HardhatUserConfig
  */
@@ -35,37 +54,37 @@ module.exports = {
   solidity: {
     compilers: [
       {
-        version: "0.4.16"
+        version: "0.4.16",
       },
       {
-        version: "0.5.16"
+        version: "0.5.16",
       },
       {
-        version: "0.6.2"
+        version: "0.6.2",
       },
       {
         version: "0.6.6",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 1000
-          }
-        }
+            runs: 1000,
+          },
+        },
       },
       {
-        version: "0.6.12"
+        version: "0.6.12",
       },
       {
-        version: "0.7.0"
+        version: "0.7.0",
       },
       {
         version: "0.7.6",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 1000
-          }
-        }
+            runs: 1000,
+          },
+        },
       },
       {
         version: "0.8.9",
@@ -73,8 +92,8 @@ module.exports = {
           optimizer: {
             enabled: true,
             runs: 1000,
-          }
-        }
+          },
+        },
       },
       {
         version: "0.8.13",
@@ -82,8 +101,8 @@ module.exports = {
           optimizer: {
             enabled: true,
             runs: 2000,
-          }
-        }
+          },
+        },
       },
       {
         version: "0.8.15",
@@ -91,17 +110,18 @@ module.exports = {
           optimizer: {
             enabled: true,
             runs: 2000,
-          }
-        }
+          },
+        },
       },
     ],
     overrides: {
       "contracts/mini-chef-zapper/MiniChefV2Zapper.sol": {
-        version: "0.8.11"
+        version: "0.8.11",
       },
       "contracts/WAVAX.sol": {
         version: "0.5.17",
-        settings: { // For mocking
+        settings: {
+          // For mocking
           outputSelection: {
             "*": {
               "*": ["storageLayout"],
@@ -109,44 +129,44 @@ module.exports = {
           },
         },
       },
-    }
+    },
   },
   networks: networksFromSdk,
   etherscan: {
     apiKey: {
-        mainnet: process.env.ETHERSCAN_API_KEY,
-        ropsten: process.env.ETHERSCAN_API_KEY,
-        rinkeby: process.env.ETHERSCAN_API_KEY,
-        goerli: process.env.ETHERSCAN_API_KEY,
-        kovan: process.env.ETHERSCAN_API_KEY,
-        // binance smart chain
-        bsc: process.env.BSCSCAN_API_KEY,
-        bscTestnet: process.env.BSCSCAN_API_KEY,
-        // huobi eco chain
-        heco: process.env.HECOINFO_API_KEY,
-        hecoTestnet: process.env.HECOINFO_API_KEY,
-        // fantom mainnet
-        opera: process.env.FTMSCAN_API_KEY,
-        ftmTestnet: process.env.FTMSCAN_API_KEY,
-        // optimism
-        optimisticEthereum: process.env.OPTIMISTIC_ETHERSCAN_API_KEY,
-        optimisticKovan: process.env.OPTIMISTIC_ETHERSCAN_API_KEY,
-        // polygon
-        polygon: process.env.POLYGONSCAN_API_KEY,
-        polygonMumbai: process.env.POLYGONSCAN_API_KEY,
-        // arbitrum
-        arbitrumOne: process.env.ARBISCAN_API_KEY,
-        arbitrumTestnet: process.env.ARBISCAN_API_KEY,
-        // avalanche
-        avalanche: process.env.SNOWTRACE_API_KEY,
-        avalancheFujiTestnet: process.env.SNOWTRACE_API_KEY,
-        // moonbeam
-        moonriver: process.env.MOONRIVER_MOONSCAN_API_KEY,
-        moonbaseAlpha: process.env.MOONBEAM_MOONSCAN_API_KEY,
-        // xdai and sokol don't need an API key, but you still need
-        // to specify one; any string placeholder will work
-        xdai: "api-key",
-        sokol: "api-key",
-    }
-  }
+      mainnet: process.env.ETHERSCAN_API_KEY,
+      ropsten: process.env.ETHERSCAN_API_KEY,
+      rinkeby: process.env.ETHERSCAN_API_KEY,
+      goerli: process.env.ETHERSCAN_API_KEY,
+      kovan: process.env.ETHERSCAN_API_KEY,
+      // binance smart chain
+      bsc: process.env.BSCSCAN_API_KEY,
+      bscTestnet: process.env.BSCSCAN_API_KEY,
+      // huobi eco chain
+      heco: process.env.HECOINFO_API_KEY,
+      hecoTestnet: process.env.HECOINFO_API_KEY,
+      // fantom mainnet
+      opera: process.env.FTMSCAN_API_KEY,
+      ftmTestnet: process.env.FTMSCAN_API_KEY,
+      // optimism
+      optimisticEthereum: process.env.OPTIMISTIC_ETHERSCAN_API_KEY,
+      optimisticKovan: process.env.OPTIMISTIC_ETHERSCAN_API_KEY,
+      // polygon
+      polygon: process.env.POLYGONSCAN_API_KEY,
+      polygonMumbai: process.env.POLYGONSCAN_API_KEY,
+      // arbitrum
+      arbitrumOne: process.env.ARBISCAN_API_KEY,
+      arbitrumTestnet: process.env.ARBISCAN_API_KEY,
+      // avalanche
+      avalanche: process.env.SNOWTRACE_API_KEY,
+      avalancheFujiTestnet: process.env.SNOWTRACE_API_KEY,
+      // moonbeam
+      moonriver: process.env.MOONRIVER_MOONSCAN_API_KEY,
+      moonbaseAlpha: process.env.MOONBEAM_MOONSCAN_API_KEY,
+      // xdai and sokol don't need an API key, but you still need
+      // to specify one; any string placeholder will work
+      xdai: "api-key",
+      sokol: "api-key",
+    },
+  },
 };

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,6 +3,8 @@ require("@nomiclabs/hardhat-ethers");
 require("@nomiclabs/hardhat-etherscan");
 const { CHAINS } = require("@pangolindex/sdk");
 require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
 
 // Create hardhat networks from @pangolindex/sdk
 let networksFromSdk = {};
@@ -150,7 +152,7 @@ module.exports = {
       ftmTestnet: process.env.FTMSCAN_API_KEY,
       // optimism
       optimisticEthereum: process.env.OPTIMISTIC_ETHERSCAN_API_KEY,
-      optimisticKovan: process.env.OPTIMISTIC_ETHERSCAN_API_KEY,
+      // optimisticKovan: process.env.OPTIMISTIC_ETHERSCAN_API_KEY, // to avoid the error
       // polygon
       polygon: process.env.POLYGONSCAN_API_KEY,
       polygonMumbai: process.env.POLYGONSCAN_API_KEY,
@@ -167,6 +169,29 @@ module.exports = {
       // to specify one; any string placeholder will work
       xdai: "api-key",
       sokol: "api-key",
+      flare: "api-key",
+      coston2: "api-key",
     },
+    // adding support for non-supported explorers
+    // see Hardhat Docs for additional information
+    // https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan#adding-support-for-other-networks
+    customChains: [
+      {
+        network: "flare",
+        chainId: 14,
+        urls: {
+          apiURL: "https://flare-explorer.flare.network/api",
+          browserURL: "https://flare-explorer.flare.network/",
+        },
+      },
+      {
+        network: "coston2",
+        chainId: 114,
+        urls: {
+          apiURL: "https://coston2-explorer.flare.network/api",
+          browserURL: "https://coston2-explorer.flare.network/",
+        },
+      },
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "homepage": "https://pangolin.exchange",
   "dependencies": {
     "@gnosis.pm/safe-core-sdk": "^1.3.0",
-    "@nomiclabs/hardhat-etherscan": "^3.0.0",
-    "@pangolindex/sdk": "3.1.6",
+    "@nomiclabs/hardhat-etherscan": "^3.1.4",
+    "@pangolindex/sdk": "4.3.0",
     "@rari-capital/solmate": "^6.4.0",
     "chance": "^1.1.8",
     "dotenv": "^14.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,6 +593,22 @@
     node-fetch "^2.6.0"
     semver "^6.3.0"
 
+"@nomiclabs/hardhat-etherscan@^3.1.4":
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.5.tgz#24f3f3272d3c79acdc933b557810ca85caef0fee"
+  integrity sha512-PxPX28AGBAlxgXLU27NB3oiMsklxbNhM75SDC4v1QPCyPeAxGm4xV0WpYbR10W7sxY2WF3Ek7u7GhjbQWa2Fcg==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^8.1.0"
+    chalk "^2.4.2"
+    debug "^4.1.1"
+    fs-extra "^7.0.1"
+    lodash "^4.17.11"
+    semver "^6.3.0"
+    table "^6.8.0"
+    undici "^5.14.0"
+
 "@nomiclabs/hardhat-waffle@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-waffle/-/hardhat-waffle-2.0.3.tgz#9c538a09c5ed89f68f5fd2dc3f78f16ed1d6e0b1"
@@ -631,10 +647,10 @@
     tiny-warning "^1.0.3"
     toformat "^2.0.0"
 
-"@pangolindex/sdk@3.1.6":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@pangolindex/sdk/-/sdk-3.1.6.tgz#326f74b7a55b4ece29d8fede9ba0ac5d13b11d6a"
-  integrity sha512-gj2U/1ND4mxJFSVMD21OTccYKk8dC7sq9fUqBCEqsByuFWBTLoTWFIt7mYphsJ76U8SdswuUELZrN8PmI6S3ig==
+"@pangolindex/sdk@4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@pangolindex/sdk/-/sdk-4.3.0.tgz#38a8da0f3beca072eb5af73eb48d4f21f4ddb24c"
+  integrity sha512-qXYepC/YVezAaFrRFZ4cHn4zPWAmEJhUzpfN6bTqUec9aHY2o86azvI9ye6usIm+hJOsSlkLKPuaisudyylM9Q==
   dependencies:
     big.js "^5.2.2"
     decimal.js-light "^2.5.0"
@@ -1051,6 +1067,16 @@ ajv@^6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -1185,6 +1211,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async-eventemitter@^0.2.2, async-eventemitter@^0.2.4:
   version "0.2.4"
@@ -2028,6 +2059,13 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "^4.3.0"
 
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 bytes@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a"
@@ -2119,6 +2157,13 @@ cbor@^5.0.2:
   dependencies:
     bignumber.js "^9.0.1"
     nofilter "^1.0.4"
+
+cbor@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
 
 chai@^4.2.0:
   version "4.3.6"
@@ -4649,6 +4694,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
@@ -5006,6 +5056,11 @@ lodash.isequalwith@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
   integrity sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA=
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 lodash@4.17.20:
   version "4.17.20"
@@ -5534,6 +5589,11 @@ nofilter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
   integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
+
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -6325,7 +6385,7 @@ require-from-string@^1.1.0:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
   integrity sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=
 
-require-from-string@^2.0.0:
+require-from-string@^2.0.0, require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
@@ -6631,6 +6691,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -6826,6 +6895,11 @@ stream-to-pull-stream@^1.7.1:
     looper "^3.0.0"
     pull-stream "^3.2.3"
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -6840,7 +6914,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6973,6 +7047,17 @@ swarm-js@^0.1.40:
     setimmediate "^1.0.5"
     tar "^4.0.2"
     xhr-request "^1.0.1"
+
+table@^6.8.0:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tape@^4.6.3:
   version "4.15.0"
@@ -7328,6 +7413,13 @@ undici@^4.14.1:
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-4.16.0.tgz#469bb87b3b918818d3d7843d91a1d08da357d5ff"
   integrity sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==
+
+undici@^5.14.0:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.15.0.tgz#cb8437c43718673a8be59df0fdd4856ff6689283"
+  integrity sha512-wCAZJDyjw9Myv+Ay62LAoB+hZLPW9SmKbQkbHIhMw/acKSlpn7WohdMUc/Vd4j1iSMBO0hWwU8mjB7a5p5bl8g==
+  dependencies:
+    busboy "^1.6.0"
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Verifying support for non-supported explorers (such as Flare, coston2, songbird etc.) is added.
- `@pangolindex/sdk` and `@nomiclabs/hardhat-etherscan` versions are updated.
- `flare` and `coston2` customChains are added in `hardhat.config.js` for verifying support.
- `networks` task is  added to see defined networks.