### PR TITLE
fix: ignore unnecessary files in npm package to reduce package size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,5 @@ typechain/
 .env
 .idea
 .vscode
+artifacts/build-info
+audits

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typechain": "^4.0.0",
     "typescript": "^4.6.3"
   },
-  "version": "2.1.9",
+  "version": "2.1.10-rc.0",
   "description": "Contracts for the Pangolin Dex.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "version": "2.1.9",
   "description": "Contracts for the Pangolin Dex.",
-  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/pangolindex/exchange-contracts.git"


### PR DESCRIPTION
This PR ignore unnecessary files from npm package.
It reduces npm package size from 96MB to 5MB